### PR TITLE
(feat) Added helm chart to deploy the application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY:
 
+unit_tests:
+	cd src && go test -v ./...
+
 build:
 	docker build --no-cache -t url-shortener .
 

--- a/charts/url-shortener/.sops.yaml
+++ b/charts/url-shortener/.sops.yaml
@@ -1,0 +1,3 @@
+---
+creation_rules:
+- pgp: '7153F1407685252E3E51B6D36DFAD53B9C69B901'

--- a/charts/url-shortener/Chart.yaml
+++ b/charts/url-shortener/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: url-shortener
+description: A Helm chart for deploying the url-shortener application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+dependencies:
+  - name: kube-prometheus-stack
+    version: "69.4.1"
+    repository: "https://prometheus-community.github.io/helm-charts"
+    condition: monitoring.installMonitoringStack
+
+  - name: ingress-nginx
+    version: "4.12.0"
+    repository: "https://kubernetes.github.io/ingress-nginx"
+    condition: ingress.enabled

--- a/charts/url-shortener/secrets.yaml
+++ b/charts/url-shortener/secrets.yaml
@@ -1,0 +1,33 @@
+password: ENC[AES256_GCM,data:B7kiDkto32I9EG4S32bQ,iv:zFR7BMw2GYDJyaKS+6sbE7JvRU8+BWBZsi1+TKzfG9I=,tag:ISVC8C6bizZ7wOuBQPd5lA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2025-03-02T17:21:53Z"
+    mac: ENC[AES256_GCM,data:d/Ph84J4CXs/bGaOSIseJnTs1FKCn3cPbWzcG7J4Xww7GmwOntiQLgeh0hgQ/u4MVBDLbgDLbvs31H6msU43uHi2j/8W0OYyvP9mhyiG5Sj8MaE2C8Jx520vna6b4t6tcI70J3bdW+EYULnreL5PcpDIz02BFMBB80VaLlbJCiM=,iv:d6Xk4HKSexW+IvEZUapOi1RWJ2HVWJyhuy1HlAneiIE=,tag:XIhkpMMNTjUu79obhkLeog==,type:str]
+    pgp:
+        - created_at: "2025-03-02T17:21:53Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA6tlAH/xK/cuAQ/9GShTr7QkFg7SaCpDbw7RqZAJnYgiREPO5toFe82f0jPk
+            sCshR/TpP0SzgaPWMzYL74TwPQzgguMj8YIln8+8hMFw9yB5K9coET0mo6NoJqwI
+            l979idPRiQYTq++1q5PCFoukTYS5JuqmZzWQTPcuzf+UQZ+UtocGu/9b+9s0F+is
+            IlGZjHxetpXgSpPgQZscyhLOuNvimHKB8vFdj0Pt+aHU7CMPt65NsJlMt7Tytk1C
+            UKxLkLaVdAPuM54ci1M1Eg3UyrEDWvGEYubrZS3C1RCBi8XpkAT4HXhqqhJYVbU9
+            vaENJxvO8dj+BpLtEfAfAEV47kup+mKRcQdhxNSeHREygmi8qBtQd8pKAOp5etYK
+            ahyfa9E7ktZyU2sHWGesV0a/p5loXVSLWREnCC65icYK67X/fCWh0aBEId5ZVk7W
+            SDICVyTImccUXfHLeUgfRz1argNzDRkRq7QaEOnYPJwu1VDXnS6HvLM8dmfFIpWL
+            K44V/pS+uwR/xVuFLDWQEqq/ekf3+ltOELmWdCt/+9w3SQFNvTchfzTnOeMcrzFo
+            ZjBrTIj3fUjTsw0ISm5Ah3MlGWdT8jeVH+nEsC11AYpozahXYeAgWFNf3MYjfncD
+            s7pmgGyGA7WHB5wjyEofARcbBKZ6FnkLuwDiT2gCPvm7c4lXq2SLHb98uuCdm+LU
+            aAEJAhApdEsLJuvVIf5gmJVg9tto3NdllwZN7hdaastjdRIYu2SYLt9qen83mBt6
+            KCQQ2uYyrO0ED9jeR7kK1Dv9HMBisbE2HcKPgaPMk3Ys0okqP3jX35Ker6E9CHkv
+            FdZ4iSPiAuxs
+            =zC84
+            -----END PGP MESSAGE-----
+          fp: 7153F1407685252E3E51B6D36DFAD53B9C69B901
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4

--- a/charts/url-shortener/templates/00-namespace.yaml
+++ b/charts/url-shortener/templates/00-namespace.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.monitoring.installMonitoringStack }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.monitoring.namespace }}
+  labels:
+    app: monitoring
+  annotations:
+    "helm.sh/hook": pre-install
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.ingress.controllerNamespace }}
+  labels:
+    app: ingress-nginx
+  annotations:
+    "helm.sh/hook": pre-install
+{{- end }}

--- a/charts/url-shortener/templates/01-secrets.yaml
+++ b/charts/url-shortener/templates/01-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-postgres-password
+  labels:
+    app: {{ .Release.Name }}
+type: Opaque
+data:
+  password: {{ .Values.password | b64enc | quote }}

--- a/charts/url-shortener/templates/02-deployment.yaml
+++ b/charts/url-shortener/templates/02-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: url-shortener
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DATABASE_HOST
+              value: "{{ .Release.Name }}-postgres"
+            - name: DATABASE_USER
+              value: {{ .Values.database.postgres.user }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgres-password
+                  key: password
+            - name: DATABASE_NAME
+              value: {{ .Values.database.postgres.dbname }}
+            - name: REDIS_HOST
+              value: "{{ .Release.Name }}-redis"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 10
+

--- a/charts/url-shortener/templates/03-service.yaml
+++ b/charts/url-shortener/templates/03-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/charts/url-shortener/templates/04-ingress.yaml
+++ b/charts/url-shortener/templates/04-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled -}}
+{{- $root := . -}}
+{{- range $namespace := .Values.ingress.namespaces }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $root.Release.Name }}-{{ $namespace.name }}-ingress
+  namespace: {{ $namespace.name }}
+  annotations:
+    {{- toYaml $root.Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ $root.Values.ingress.className | default "nginx" }}
+  rules:
+    - host: "k8s.local"
+      http:
+        paths:
+        {{- range $service := $namespace.services }}
+          - path: {{ $service.path | quote }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $service.service.name }}
+                port:
+                  number: {{ $service.service.port }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/url-shortener/templates/05-nodeport-service.yaml
+++ b/charts/url-shortener/templates/05-nodeport-service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.nodePortService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-nodeport
+spec:
+  type: NodePort
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.nodePortService.port }}
+      targetPort: 8080
+      nodePort: {{ .Values.nodePortService.nodePort }}
+{{- end }}

--- a/charts/url-shortener/templates/06-postgres-deployment.yaml
+++ b/charts/url-shortener/templates/06-postgres-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.database.postgres.image }}"
+          env:
+            - name: POSTGRES_USER
+              value: "{{ .Values.database.postgres.user }}"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgres-password
+                  key: password
+            - name: POSTGRES_DB
+              value: "{{ .Values.database.postgres.dbname }}"
+          volumeMounts:
+            - name: init-script
+              mountPath: /docker-entrypoint-initdb.d/
+          ports:
+            - containerPort: {{ .Values.database.postgres.port }}
+      volumes:
+        - name: init-script
+          configMap:
+            name: {{ .Release.Name }}-postgres-init

--- a/charts/url-shortener/templates/07-postgres-init-cm.yaml
+++ b/charts/url-shortener/templates/07-postgres-init-cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-postgres-init
+data:
+  init.sql: |
+    {{- .Values.database.postgres.initScript | nindent 4 }}

--- a/charts/url-shortener/templates/08-postgres-service.yaml
+++ b/charts/url-shortener/templates/08-postgres-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgres
+spec:
+  selector:
+    app: {{ .Release.Name }}-postgres
+  ports:
+    - protocol: TCP
+      port: {{ .Values.database.postgres.port }}
+      targetPort: {{ .Values.database.postgres.port }}

--- a/charts/url-shortener/templates/09-redis-deployment.yaml
+++ b/charts/url-shortener/templates/09-redis-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-redis
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.cache.redis.image }}"
+          ports:
+            - containerPort: {{ .Values.cache.redis.port }}

--- a/charts/url-shortener/templates/10-redis-service.yaml
+++ b/charts/url-shortener/templates/10-redis-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+spec:
+  selector:
+    app: {{ .Release.Name }}-redis
+  ports:
+    - protocol: TCP
+      port: {{ .Values.cache.redis.port }}
+      targetPort: {{ .Values.cache.redis.port }}

--- a/charts/url-shortener/values.yaml
+++ b/charts/url-shortener/values.yaml
@@ -1,0 +1,97 @@
+replicaCount: 1
+
+image:
+  repository: andreidon1/url-shortener
+  tag: v0.0.3
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8080
+
+database:
+  postgres:
+    enabled: true
+    image: postgres:17.2-alpine
+    host: postgres
+    user: admin
+    password: password
+    dbname: my_db
+    port: 5432
+    initScript: |-
+      CREATE TABLE urls (
+          id SERIAL PRIMARY KEY,
+          short_url TEXT UNIQUE NOT NULL,
+          original_url TEXT NOT NULL,
+          created_at TIMESTAMP DEFAULT NOW()
+      );
+
+cache:
+  redis:
+    enabled: true
+    image: redis:8.0-M03-alpine
+    name: redis
+    port: 6379
+
+nodePortService:
+  enabled: true
+  port: 8080
+  nodePort: 30080
+
+monitoring:
+  installMonitoringStack: true
+  namespace: monitoring
+
+kube-prometheus-stack:
+  namespaceOverride: monitoring
+  alertmanager:
+    enabled: false
+  grafana:
+    namespaceOverride: monitoring
+    grafana.ini:
+      server:
+        root_url: http://k8s.local/grafana
+        serve_from_sub_path: true
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      path: /grafana
+      hosts:
+        - "k8s.local"
+  kube-state-metrics:
+    namespaceOverride: monitoring
+  prometheus-node-exporter:
+    namespaceOverride: monitoring
+  prometheus:
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      hosts:
+        - "k8s.local"
+      paths:
+        - /prom
+      prometheusSpec:
+        externalUrl: "http://k8s.local/prom"
+
+ingress:
+  enabled: true
+  controllerNamespace: ingress-nginx
+  namespaces:
+    - name: default
+      services:
+        - path: /url-shortener(/|$)(.*)
+          service:
+            name: url-shortener
+            port: 8080
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+
+ingress-nginx:
+  namespaceOverride: ingress-nginx
+  controller:
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          release: url-shortener

--- a/src/config/database.go
+++ b/src/config/database.go
@@ -3,22 +3,33 @@ package config
 import (
 	"database/sql"
 	"fmt"
+	"log"
+
+	"time"
 
 	_ "github.com/lib/pq"
 )
 
 var sqlOpen = sql.Open
 
-func ConnectDatabase(dsn string) (*sql.DB, error) {
-	db, err := sqlOpen("postgres", dsn)
-	if err != nil {
-		return nil, err
-	}
+func ConnectDatabase(dsn string, maxRetries int, retryInterval time.Duration) (*sql.DB, error) {
 
-	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("database is not reachable: %v", err)
-	}
+	var db *sql.DB
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		db, err = sqlOpen("postgres", dsn)
+		if err != nil {
+			log.Printf("Failed to open database connection (attempt %d/%d): %v", i+1, maxRetries, err)
+			time.Sleep(retryInterval)
+			continue
+		}
 
-	fmt.Println("Successfully connected!")
-	return db, nil
+		if err = db.Ping(); err == nil {
+			fmt.Println("Successfully connected!")
+			return db, nil
+		}
+		log.Printf("Failed to ping database (attempt %d/%d): %v", i+1, maxRetries, err)
+		time.Sleep(retryInterval)
+	}
+	return nil, fmt.Errorf("could not connect to database after %d retries: %v", maxRetries, err)
 }

--- a/src/config/database_test.go
+++ b/src/config/database_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestConnectDatabase(t *testing.T) {
 			return dbPsql, nil
 		}
 
-		db, err := ConnectDatabase("mock_dsn")
+		db, err := ConnectDatabase("mock_dsn", 3, 1*time.Second)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, db)
@@ -39,9 +40,9 @@ func TestConnectDatabase(t *testing.T) {
 			return nil, expectedErr
 		}
 
-		db, err := ConnectDatabase("invalid_dsn")
+		db, err := ConnectDatabase("invalid_dsn", 1, 1*time.Second)
 		assert.Nil(t, db)
-		assert.ErrorIs(t, err, expectedErr)
+		assert.EqualError(t, err, fmt.Sprintf("could not connect to database after 1 retries: %v", expectedErr))
 	})
 
 	t.Run("Failure in db.Ping", func(t *testing.T) {
@@ -55,9 +56,9 @@ func TestConnectDatabase(t *testing.T) {
 			return dbPsql, nil
 		}
 
-		db, err := ConnectDatabase("mock_dsn")
+		db, err := ConnectDatabase("mock_dsn", 1, 1*time.Second)
 		assert.Nil(t, db)
-		assert.EqualError(t, err, fmt.Sprintf("database is not reachable: %v", expectedErr))
+		assert.EqualError(t, err, fmt.Sprintf("could not connect to database after 1 retries: %v", expectedErr))
 		assert.NoError(t, mockPsql.ExpectationsWereMet())
 	})
 }


### PR DESCRIPTION
This commit adds the helm chart to deploy the application. Helm chart dependencies were added for nginx ingress controller and kube-prometheus-stack which can be disabled based on Helm chart values.

The application code was modified to support database connection retries and prevent the pod from crashing on startup. An additional healthz endpoint was added to test connections to Redis and Postgres. This endpoint is used by the ReadinessProbe to check if the application pod can connect to its dependencies before marking the container as 'Ready'.

In order to pass the postgres password to the database and to the application, we are making use of the helm-secrets plugin which decrypts secrets on the fly during the helm release installation.