### PR TITLE
Adding instrumentation

### DIFF
--- a/charts/url-shortener/templates/03-service.yaml
+++ b/charts/url-shortener/templates/03-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
   selector:
@@ -10,3 +12,7 @@ spec:
     - protocol: TCP
       port: {{ .Values.service.port }}
       targetPort: 8080
+      name: app
+    - name: metrics
+      port: 9090
+      targetPort: 9090

--- a/charts/url-shortener/templates/11-service-monitor.yaml
+++ b/charts/url-shortener/templates/11-service-monitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.monitoring.installMonitoringStack }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-monitor
+  namespace: {{ .Values.monitoring.namespace }}
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - default 
+  endpoints:
+    - port: metrics
+      interval: 15s
+{{- end }}

--- a/charts/url-shortener/values.yaml
+++ b/charts/url-shortener/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: andreidon1/url-shortener
-  tag: v0.0.3
+  tag: v0.0.4
   pullPolicy: IfNotPresent
 
 service:
@@ -15,7 +15,6 @@ database:
     image: postgres:17.2-alpine
     host: postgres
     user: admin
-    password: password
     dbname: my_db
     port: 5432
     initScript: |-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - redis
     ports:
       - "8080:8080"
+      - "9090:9090"
     networks:
       - app_network
 

--- a/dockerfile
+++ b/dockerfile
@@ -11,6 +11,6 @@ RUN go build -o url-shortener .
 FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /app/url-shortener .
-EXPOSE 8080
+EXPOSE 8080 9090
 
 CMD ["./url-shortener"]

--- a/src/go.mod
+++ b/src/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.12.8 // indirect
 	github.com/bytedance/sonic/loader v0.2.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -26,15 +27,21 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	github.com/prometheus/client_golang v1.21.1 // indirect
+	github.com/prometheus/client_model v0.6.1 // indirect
+	github.com/prometheus/common v0.62.0 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.13.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -46,6 +48,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
@@ -54,6 +58,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -69,6 +75,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -80,11 +88,21 @@ github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xl
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=
+github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
+github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
+github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
+github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
+github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
+github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
+github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/src/handlers/redirect.go
+++ b/src/handlers/redirect.go
@@ -4,19 +4,65 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/andrei-don/url-shortener/config"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 )
+
+var (
+	redirectCounterRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "redirect_requests_total",
+			Help: "Total number of requests to the /redirect endpoint.",
+		},
+		[]string{"status"},
+	)
+
+	redirectHistogramLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "redirect_request_latency_seconds",
+			Help:    "Latency of requests to the /redirect endpoint.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"status"},
+	)
+
+	redisCacheHits = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "redis_cache_hits_total",
+			Help: "Total number of Redis cache hits.",
+		},
+	)
+
+	redisCacheMisses = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "redis_cache_misses_total",
+			Help: "Total number of Redis cache misses.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(redirectCounterRequests)
+	prometheus.MustRegister(redirectHistogramLatency)
+	prometheus.MustRegister(redisCacheHits)
+	prometheus.MustRegister(redisCacheMisses)
+}
 
 func redirect(c *gin.Context, dbPsql *sql.DB, dbRedis *redis.Client) {
 	shortCode := c.Param("shortUrl")
 
+	start := time.Now()
 	url, err := dbRedis.Get(config.Ctx, shortCode).Result()
 	if err == nil {
 		c.Redirect(http.StatusFound, url)
 		log.Printf("Cache hit for %s", url)
+		redirectCounterRequests.WithLabelValues("302").Inc()
+		redirectHistogramLatency.WithLabelValues("302").Observe(time.Since(start).Seconds())
+		redisCacheHits.Inc()
 		return
 	}
 
@@ -24,6 +70,8 @@ func redirect(c *gin.Context, dbPsql *sql.DB, dbRedis *redis.Client) {
 	err = row.Scan(&url)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "URL not found"})
+		redirectCounterRequests.WithLabelValues("404").Inc()
+		redirectHistogramLatency.WithLabelValues("404").Observe(time.Since(start).Seconds())
 		return
 	}
 
@@ -31,6 +79,9 @@ func redirect(c *gin.Context, dbPsql *sql.DB, dbRedis *redis.Client) {
 	dbRedis.Set(config.Ctx, shortCode, url, 0)
 	log.Printf("Cache miss for %s", url)
 	c.Redirect(http.StatusFound, url)
+	redirectCounterRequests.WithLabelValues("302").Inc()
+	redirectHistogramLatency.WithLabelValues("302").Observe(time.Since(start).Seconds())
+	redisCacheMisses.Inc()
 }
 
 func RedirectHandler(dbPsql *sql.DB, dbRedis *redis.Client) gin.HandlerFunc {

--- a/src/handlers/shorten.go
+++ b/src/handlers/shorten.go
@@ -4,10 +4,12 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/andrei-don/url-shortener/config"
 	"github.com/andrei-don/url-shortener/utils"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -15,10 +17,38 @@ type ShortenRequest struct {
 	URL string
 }
 
+var (
+	shortenCounterRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "shorten_requests_total",
+			Help: "Total number of requests to the /shorten endpoint.",
+		},
+		[]string{"status"},
+	)
+
+	shortenHistogramLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "shorten_request_latency_seconds",
+			Help:    "Latency of requests to the /shorten endpoint.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(shortenCounterRequests)
+	prometheus.MustRegister(shortenHistogramLatency)
+}
+
 func shortenUrl(c *gin.Context, dbPsql *sql.DB, dbRedis *redis.Client) {
 	var req ShortenRequest
+
+	start := time.Now()
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		shortenCounterRequests.WithLabelValues("400").Inc()
+		shortenHistogramLatency.WithLabelValues("400").Observe(time.Since(start).Seconds())
 		return
 	}
 
@@ -31,18 +61,24 @@ func shortenUrl(c *gin.Context, dbPsql *sql.DB, dbRedis *redis.Client) {
 			"message":   fmt.Sprintf("URL %s is already shortened.", req.URL),
 			"short_url": "http://localhost:8080/" + existingShortURL,
 		})
+		shortenCounterRequests.WithLabelValues("200").Inc()
+		shortenHistogramLatency.WithLabelValues("200").Observe(time.Since(start).Seconds())
 		return
 	}
 
 	_, err = dbPsql.Exec("INSERT INTO urls (short_url, original_url) VALUES ($1, $2)", shortCode, req.URL)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+		shortenCounterRequests.WithLabelValues("500").Inc()
+		shortenHistogramLatency.WithLabelValues("500").Observe(time.Since(start).Seconds())
 		return
 	}
 
 	dbRedis.Set(config.Ctx, shortCode, req.URL, 0)
 
 	c.JSON(http.StatusOK, gin.H{"short_url": "http://localhost:8080/" + shortCode})
+	shortenCounterRequests.WithLabelValues("200").Inc()
+	shortenHistogramLatency.WithLabelValues("200").Observe(time.Since(start).Seconds())
 }
 
 func ShortenUrlHandler(dbPsql *sql.DB, dbRedis *redis.Client) gin.HandlerFunc {

--- a/src/main.go
+++ b/src/main.go
@@ -10,12 +10,21 @@ import (
 	"github.com/andrei-don/url-shortener/config"
 	"github.com/andrei-don/url-shortener/handlers"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
 	psqlPort  = 5432
 	redisPort = 6379
 )
+
+func startMetricsServer() {
+	http.Handle("/metrics", promhttp.Handler())
+	log.Println("Starting metrics server on :9090")
+	if err := http.ListenAndServe(":9090", nil); err != nil {
+		log.Fatalf("Failed to start metrics server: %v", err)
+	}
+}
 
 func main() {
 	host := os.Getenv("DATABASE_HOST")
@@ -38,6 +47,7 @@ func main() {
 		log.Fatalf("Cannot connect to Redis: %v", err)
 	}
 
+	go startMetricsServer()
 	r := gin.Default()
 
 	r.GET("/healthz", func(c *gin.Context) {


### PR DESCRIPTION
This PR adds Prometheus instrumentation for the following metrics:

- shorten_requests_total
- shorten_request_latency_seconds
- redirect_requests_total
- redirect_request_latency_seconds
- redis_cache_hits_total
- redis_cache_misses_total

An http server is started on port 9090 to expose the metrics on the /metrics endpoint. The dockerfile and docker-compose were amended to reflect that.

The helm chart was also amended to include a ServiceMonitor to scrape the metrics exposed by the application.