### PR TITLE
(feat) Added env variable for baseURL

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
       DATABASE_NAME: ${POSTGRES_DB}
       REDIS_HOST: "redis"
+      BASE_URL: "http://localhost:8080"
     depends_on:
       - postgres
       - redis

--- a/src/handlers/shorten_test.go
+++ b/src/handlers/shorten_test.go
@@ -21,7 +21,7 @@ func TestShorten_BadRequest(t *testing.T) {
 	assert.NoError(t, err)
 
 	router := gin.Default()
-	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis))
+	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis, "http://localhost:8080"))
 
 	reqBody := []byte(`{"url": "http://example.com"`)
 
@@ -41,7 +41,7 @@ func TestShorten_ExistingUrl(t *testing.T) {
 	assert.NoError(t, err)
 
 	router := gin.Default()
-	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis))
+	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis, "http://localhost:8080"))
 
 	originalUrl := "http://this-is-my-url.com"
 	existingShortUrl := "test"
@@ -78,7 +78,7 @@ func TestShorten_DatabaseInsert(t *testing.T) {
 	shortUrl := utils.GenerateShortCode(originalUrl)
 
 	router := gin.Default()
-	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis))
+	router.POST("/shorten", ShortenUrlHandler(dbPsql, dbRedis, "http://localhost:8080"))
 
 	t.Run("Insert Success", func(t *testing.T) {
 		mockPsql.ExpectExec(`INSERT INTO urls \(short_url, original_url\) VALUES \(\$1, \$2\)`).WithArgs(shortUrl, originalUrl).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/src/main.go
+++ b/src/main.go
@@ -31,6 +31,7 @@ func main() {
 	user := os.Getenv("DATABASE_USER")
 	password := os.Getenv("DATABASE_PASSWORD")
 	dbname := os.Getenv("DATABASE_NAME")
+	baseUrl := os.Getenv("BASE_URL")
 	addr := fmt.Sprintf("%s:%d", os.Getenv("REDIS_HOST"), redisPort)
 
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+
@@ -48,6 +49,7 @@ func main() {
 	}
 
 	go startMetricsServer()
+	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 
 	r.GET("/healthz", func(c *gin.Context) {
@@ -73,7 +75,7 @@ func main() {
 		})
 	})
 
-	r.POST("/shorten", handlers.ShortenUrlHandler(dbPsql, dbRedis))
+	r.POST("/shorten", handlers.ShortenUrlHandler(dbPsql, dbRedis, baseUrl))
 	r.GET("/:shortUrl", handlers.RedirectHandler(dbPsql, dbRedis))
 	r.Run(":8080")
 }


### PR DESCRIPTION
The shorten endpoint returns the shortURL which is a combination between the baseURL where the application is accessed and the short URL. This commit allows the user to pass the baseURL as an env variable so that the response from the shorten endpoint is a working link.