### PR TITLE
(feat) Added logic for restoring db from PVC

### DIFF
--- a/charts/url-shortener/templates/05-postgres-deployment.yaml
+++ b/charts/url-shortener/templates/05-postgres-deployment.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   instances: 1
   bootstrap:
+    {{- if .Values.database.postgres.restoreFromBackup.enabled }}
+    recovery:
+      volumeSnapshots:
+        storage:
+          apiGroup: ""
+          kind: PersistentVolumeClaim
+          name: {{ .Values.database.postgres.restoreFromBackup.PVC }}
+    {{- else}}
     initdb:
       database: app
       owner: app
@@ -12,6 +20,8 @@ spec:
         configMapRefs:
           - name: {{ .Release.Name }}-postgres-init
             key: init.sql
+    {{- end }}
   storage:
     size: 5Gi
-    storageClass: {{ .Values.storageClass.name }}
+    storageClass: {{ .Values.database.postgres.storageClassName }}
+    resizeInUseVolumes: False

--- a/charts/url-shortener/templates/07-redis-deployment.yaml
+++ b/charts/url-shortener/templates/07-redis-deployment.yaml
@@ -8,7 +8,7 @@ spec:
   storage:
     volumeClaimTemplate:
       spec:
-        storageClassName: {{ .Values.storageClass.name }}
+        storageClassName: {{ .Values.database.redis.storageClassName }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/charts/url-shortener/values.yaml
+++ b/charts/url-shortener/values.yaml
@@ -11,6 +11,10 @@ app:
 
 database:
   postgres:
+    storageClassName: longhorn
+    restoreFromBackup:
+      enabled: false
+      PVC: postgres-restored
     initScript: |-
       CREATE TABLE urls (
           id SERIAL PRIMARY KEY,
@@ -20,9 +24,8 @@ database:
       );
       GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE urls TO app;
       GRANT USAGE, SELECT ON SEQUENCE urls_id_seq TO app;
-
-storageClass:
-  name: longhorn
+  redis:
+    storageClassName: longhorn
 
 nodePortService:
   enabled: true


### PR DESCRIPTION
While experimenting with Longhorn backup, I wanted to restore the backup for the postgres db. Added logic to restore the Postgres db from existing PVC (generated from a Longhorn restored backup).